### PR TITLE
get users with erc20 addresses

### DIFF
--- a/wp/core/Plugin.php
+++ b/wp/core/Plugin.php
@@ -18,12 +18,16 @@ class Plugin extends Singleton {
 	 *
 	 * @param array $data
 	 */
-	public function __construct( array $data = [] ) {
+	public function __construct( array $data = array() ) {
 
 		parent::__construct();
 
 		add_action( 'init', array( $this, 'init_actions' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'rest_api_init', array( $this, 'add_users_api_route' ) );
+
+		// Enable application passwords for api.
+		add_filter( 'wp_is_application_passwords_available', '__return_true' );
 
 	}
 
@@ -34,6 +38,49 @@ class Plugin extends Singleton {
 	public function enqueue_assets() {
 		wp_register_style( 'stakeborg-badges', SBORG_BADGES_ASSETS_URL . 'build/main.css', array(), SBORG_BADGES_VERSION, 'all' );
 		wp_register_script( 'stakeborg-badges', SBORG_BADGES_ASSETS_URL . 'build/main.js', array(), SBORG_BADGES_VERSION, true );
+	}
+
+	public function add_users_api_route() {
+		register_rest_route(
+			'badges/v1',
+			'/users',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'get_users_data' ),
+				'permission_callback' => function () {
+					return current_user_can( 'edit_others_posts' ); // editor.
+				},
+			)
+		);
+	}
+
+	public function get_users_data() {
+
+		if ( ! function_exists( 'xprofile_get_field_data' ) ) {
+			return array();
+		}
+
+		$data  = array();
+		$users = get_users();
+		if ( ! empty( $users ) ) {
+			foreach ( $users as $user ) {
+
+				$erc20 = xprofile_get_field_data( 'ERC20 Address', $user->ID );
+
+				if ( ! $erc20 ) {
+					continue;
+				}
+
+				$data[ $user->ID ] = array(
+					'username' => $user->user_login,
+					'name'     => $user->display_name,
+					'email'    => $user->user_email,
+					'erc20'    => $erc20,
+				);
+			}
+		}
+
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
**Get a list of users info with erc20 addresses:**
- username
- name
- email
- erc20

_**Note:**_
The route is protected so you need to provide authentication headers. The user you are making the request as should be at least Editor role.

**Send request example:**
```
var config = {
  method: 'get',
  url: 'https://stakeborgdao.xyz/wp-json/badges/v1/users',
  headers: { 
    'Authorization': 'Basic Z2FicmllbDpZV1pZIFd4R1UgZVN4biBpN0taIDk4ZjYgWWRtSg=='
  }
};
```
Basic authentication is the standard in the industry. it is a base64_encode string complied from your username and Application password like base64encode(user:app_pass).

Example in PHP:
$username = 'gabriel'; // site username
$application_password = 'Xo9c 9vGs AOBG nXb0 FPpr W5vO';
  
echo base64_encode($username.':'.$application_password);

Application passwords will be enabled after this commit and you can generate one from your WordPress profile(just make sure to be logged in):
https://stakeborgdao.xyz/wp-admin/profile.php
<img width="1147" alt="app-passwords-profile-area" src="https://user-images.githubusercontent.com/5703385/153726256-f5035ddb-14f7-4cf0-97b3-500c326bf165.png">

Example response:
`{"1":{"username":"gabriel","name":"Gabi","email":"gabriel@codez.ro","erc20":"0x11122330004123123"}}`